### PR TITLE
Fix multicast reception: restore AcceptMulticast in rtl8125_set_rx_mode()

### DIFF
--- a/src/r8125_n.c
+++ b/src/r8125_n.c
@@ -11822,6 +11822,7 @@ rtl8125_set_rx_mode(struct net_device *dev)
                 netdev_for_each_mc_addr(ha, dev) {
                         u32 bit_nr = eth_hw_addr_crc(ha) >> 26;
                         mc_filter[bit_nr >> 5] |= 1 << (bit_nr & 31);
+                        rx_mode |= AcceptMulticast;
                 }
         }
 


### PR DESCRIPTION
## Problem

Multicast reception is broken: the NIC hardware-filters all multicast frames unless the interface is in ALLMULTI or PROMISC mode. Practical symptom: mDNS/IGMP do not work — the kernel joins the groups (`ip maddr` shows them) and the MAR hash filter is programmed, but no multicast frame is ever delivered.

Observed on a Rock 5B+ (RK3588, RTL8125B rev 05, XID 641, Radxa BSP kernel 6.1.84) running 9.014.01: mDNS resolution of the host stopped the moment this driver replaced the vendor one, and started working again with `ip link set eth0 allmulticast on`.

## Cause

`rtl8125_set_rx_mode()` programs the multicast hash filter (MAR0/MAR4) correctly, but never sets the `AcceptMulticast` bit in `rx_mode` on the normal path — only the ALLMULTI branch (and PROMISC via `AcceptAllPhys`) enables multicast acceptance. The vendor driver sets `rx_mode |= AcceptMulticast;` inside the `netdev_for_each_mc_addr()` loop (see `rtl8125_hw_set_rx_packet_filter()` in the 9.016.01 vendor source); this line was dropped in the rewrite.

## Fix

Restore that line inside the loop (one-line change in `src/r8125_n.c`).

## Testing

- Rock 5B+ (RK3588), Radxa BSP kernel 6.1.84, RTL8125B rev 05 @ 1GbE
- Before: mDNS queries never reach the host unless ALLMULTI is set. After: mDNS (systemd-resolved responder) works with the specific-groups hash filter, ALLMULTI off.
- Data path unaffected: multi-GB TLS downloads remain corruption-free after the change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
